### PR TITLE
Make the cutback factor user-defined via input file

### DIFF
--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -182,6 +182,7 @@ class NIST:
         maxIter = step.maxIter
         criticalIter = step.criticalIter
         maxGrowingIter = step.maxGrowIter
+        cutbackFactor = step.cutbackFactor
 
         # nodes = model.nodes
         # elements = model.elements
@@ -245,7 +246,7 @@ class NIST:
 
                 except CutbackRequest as e:
                     self.journal.message(str(e), self.identification, 1)
-                    step.discardAndChangeIncrement(max(e.cutbackSize, 0.25))
+                    step.discardAndChangeIncrement(max(e.cutbackSize, cutbackFactor))
                     prevTimeStep = None
 
                     statusInfoDict["iters"] = np.inf
@@ -262,7 +263,7 @@ class NIST:
 
                 except (ReachedMaxIterations, DivergingSolution) as e:
                     self.journal.message(str(e), self.identification, 1)
-                    step.discardAndChangeIncrement(0.25)
+                    step.discardAndChangeIncrement(cutbackFactor)
                     prevTimeStep = None
 
                     statusInfoDict["iters"] = np.inf
@@ -279,6 +280,7 @@ class NIST:
 
                 else:
                     prevTimeStep = timeStep
+
                     if iterationCounter >= criticalIter:
                         step.preventIncrementIncrease()
 

--- a/edelweissfe/steps/adaptivestep.py
+++ b/edelweissfe/steps/adaptivestep.py
@@ -60,6 +60,7 @@ class AdaptiveStep(StepBase):
     defaultMaxIter = 10
     defaultCriticalIter = 5
     defaultMaxGrowingIter = 10
+    defaultCutbackFactor = 0.25
 
     def __init__(
         self,
@@ -102,6 +103,9 @@ class AdaptiveStep(StepBase):
         self.maxGrowIter = kwargs.get(
             "maxGrowIter", self.defaultMaxGrowingIter
         )  #: The number of residual growths before the increment is discarded.
+        self.cutbackFactor = kwargs.get(
+            "cutbackFactor", self.defaultCutbackFactor
+        )  #: Factor by which the increment size is reduced if no convergence was achieved.
 
         self.incrementGenerator = AdaptiveTimeStepper(
             model.time,

--- a/edelweissfe/utils/inputfileparser.py
+++ b/edelweissfe/utils/inputfileparser.py
@@ -191,6 +191,10 @@ inputLanguage = {
                 "integer",
                 "maximum number of iterations to prevent from increasing the increment",
             ),
+            "cutbackFactor": (
+                "float",
+                "factor by which the increment size is reduced if no convergence was achieved",
+            ),
             "data": (
                 "string",
                 "define step actions, which are handled by the corresponding stepaction modules",


### PR DESCRIPTION
This pull request modifies the handling of the cutback factor in the nonlinear solver to make it configurable through the user input file, instead of being hardcoded in the source code.
If the user does not specify a value, the solver automatically uses the default value.